### PR TITLE
Add first hardcoded prototype of the listings page.

### DIFF
--- a/src/main/webapp/browse.css
+++ b/src/main/webapp/browse.css
@@ -1,0 +1,159 @@
+:root {
+    --blue: #1a73e8;
+    --blue-background: #f6fafe;
+    --dark-gray: #5f6368;
+    --light-gray: #dadce0;
+    --gray-background: #f6f6f6;
+    --green: #0d9104;
+}
+
+#content {
+    font-family: Roboto, Helvetica Neue, sans-serif;;
+}
+
+/* Navigation Bar */
+#navbar {
+    height: 64px;
+    line-height: 64px;
+    display: flex;
+    flex-direction: row;
+}
+
+#navcorner {
+    height: 100%;
+    width: 60px;
+}
+
+#navlinks {
+    display: flex;
+    position: relative;
+    justify-content: flex-end;
+    height: 100%;
+    flex: 1;
+    text-align: right;
+}
+
+#navlinks a {
+    padding-left: 24px;
+    padding-right: 24px;
+    color: var(--blue);
+    text-decoration: none;
+    font-weight: 500;
+    font-size: 16px;
+    letter-spacing: .1px;
+    height: 100%;
+}
+
+.navlink :hover {
+    background-color: var(--blue-background);
+    border-bottom: var(--blue) 2px;
+}
+
+
+/* Category Title */
+#category-title {
+    text-align: center;
+    font-size: 42px;
+    color: var(--dark-gray);
+}
+
+
+/* Filter & Search Bar */
+#toolbar {
+    border-color: var(--light-gray);
+    border-width: 1px;
+    border-style: solid;
+    border-radius: 20px;
+    padding: 10px;
+    margin: 20px 20px;
+}
+
+
+/* Listings */
+#listing-counter {
+    padding-bottom: 5px;
+    color: var(--dark-gray);
+    font-size: 15px;
+}
+
+#listings {
+    display: inline-grid;
+    grid-template-columns: repeat(3, 1fr);
+    gap: 10px;
+    grid-auto-rows: minmax(100px, auto);
+}
+
+.listing {
+    border-radius: 8px;
+    border-width: 1px;
+    border-style: solid;
+    border-color: var(--light-gray);
+    padding: 10px;
+    color: var(--dark-gray);
+}
+
+.listing-header {
+    display: flex;
+    flex-direction: row;
+}
+
+.listing-title {
+    font-weight: bold;
+    font-size: 18px;
+}
+
+.listing-age {
+    display: flex;
+    position: relative;
+    justify-content: flex-end;
+    flex: 1;
+    text-align: right;
+    font-size: 12px;
+}
+
+.listing-subtitle {
+    font-size: 14px;
+    line-height: 20px;
+    padding-bottom: 10px;
+}
+
+.listing-description {
+    padding-bottom: 10px;
+}
+
+.listing-capacity {
+    font-size: 23px;
+    font-weight: bold;
+    padding-bottom: 10px;
+}
+
+.listing-sub-description {
+    padding-bottom: 10px;
+}
+
+.listing-buttons {
+    display: flex;
+    justify-content: space-between;
+}
+
+.listing-buttons button {
+    padding: 0 24px;
+    position: relative;
+    text-align: center;
+    font-size: 14px;
+    font-weight: 500;
+    letter-spacing: .25px;
+    line-height: 36px;
+    border: none;
+    border-radius: 4px;
+}
+
+.listing-button-detail {
+    background: var(--light-gray);
+    color: var(--dark-gray);
+}
+
+.listing-button-join {
+    background: var(--blue);
+    color: white;
+}

--- a/src/main/webapp/browse.html
+++ b/src/main/webapp/browse.html
@@ -1,0 +1,105 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <meta charset="UTF-8">
+    <title>Browse Listings</title>
+    <link rel="stylesheet" href="browse.css">
+    <script src="browse.js"></script>
+</head>
+<body>
+<div id="content">
+    <div id="navbar">
+        <div id="navcorner"></div>
+        <div id="navlogo"><b>SPS</b> Meeting App Name</div>
+        <div id="navlinks">
+            <div class="navlink"><a href="">Browse Listings</a></div>
+            <div class="navlink"><a href="">About</a></div>
+            <div class="navlink"><a href="">Account</a></div>
+<!--            <a href="">About</a>-->
+<!--            <a href="">Account</a>-->
+        </div>
+    </div>
+    <hr>
+
+    <div id="category-title">Listing Category Title</div>
+
+    <div id="toolbar">
+        Searchbar & Filter placeholder
+    </div>
+
+    <div id="listing-counter">5 of 5 listings</div>
+    <div id="listings">
+        <div class="listing">
+            <div class="listing-header">
+                <div class="listing-title">Listing Title</div>
+                <div class="listing-age">20 seconds ago</div>
+            </div>
+            <div class="listing-subtitle">created by Author</div>
+            <div class="listing-description">Short listing description. Lorem ipsum dolor sit amet, consectetur adipiscing elit. Phasellus sed ipsum et tellus dapibus vestibulum. Sed cursus tempor ultrices. Donec volutpat metus sed risus venenatis, euismod viverra elit varius.</div>
+            <div class="listing-capacity">0 spots open</div>
+            <div class="listing-sub-description">Location or other meeting details depending on the category</div>
+            <div class="listing-buttons">
+                <button class="listing-button-detail">See details</button>
+                <button class="listing-button-join">Join</button>
+            </div>
+        </div>
+        <div class="listing">
+            <div class="listing-header">
+                <div class="listing-title">Listing Title</div>
+                <div class="listing-age">20 seconds ago</div>
+            </div>
+            <div class="listing-subtitle">created by Author</div>
+            <div class="listing-description">Short listing description. Lorem ipsum dolor sit amet, consectetur adipiscing elit. Phasellus sed ipsum et tellus dapibus vestibulum. Sed cursus tempor ultrices. Donec volutpat metus sed risus venenatis, euismod viverra elit varius.</div>
+            <div class="listing-capacity">0 spots open</div>
+            <div class="listing-sub-description">Location or other meeting details depending on the category</div>
+            <div class="listing-buttons">
+                <button class="listing-button-detail">See details</button>
+                <button class="listing-button-join">Join</button>
+            </div>
+        </div>
+        <div class="listing">
+            <div class="listing-header">
+                <div class="listing-title">Listing Title</div>
+                <div class="listing-age">20 seconds ago</div>
+            </div>
+            <div class="listing-subtitle">created by Author</div>
+            <div class="listing-description">Short listing description. Lorem ipsum dolor sit amet, consectetur adipiscing elit. Phasellus sed ipsum et tellus dapibus vestibulum. Sed cursus tempor ultrices. Donec volutpat metus sed risus venenatis, euismod viverra elit varius.</div>
+            <div class="listing-capacity">0 spots open</div>
+            <div class="listing-sub-description">Location or other meeting details depending on the category</div>
+            <div class="listing-buttons">
+                <button class="listing-button-detail">See details</button>
+                <button class="listing-button-join">Join</button>
+            </div>
+        </div>
+        <div class="listing">
+            <div class="listing-header">
+                <div class="listing-title">Listing Title</div>
+                <div class="listing-age">20 seconds ago</div>
+            </div>
+            <div class="listing-subtitle">created by Author</div>
+            <div class="listing-description">Short listing description. Lorem ipsum dolor sit amet, consectetur adipiscing elit. Phasellus sed ipsum et tellus dapibus vestibulum. Sed cursus tempor ultrices. Donec volutpat metus sed risus venenatis, euismod viverra elit varius.</div>
+            <div class="listing-capacity">0 spots open</div>
+            <div class="listing-sub-description">Location or other meeting details depending on the category</div>
+            <div class="listing-buttons">
+                <button class="listing-button-detail">See details</button>
+                <button class="listing-button-join">Join</button>
+            </div>
+        </div>
+        <div class="listing">
+            <div class="listing-header">
+                <div class="listing-title">Listing Title</div>
+                <div class="listing-age">20 seconds ago</div>
+            </div>
+            <div class="listing-subtitle">created by Author</div>
+            <div class="listing-description">Short listing description. Lorem ipsum dolor sit amet, consectetur adipiscing elit. Phasellus sed ipsum et tellus dapibus vestibulum. Sed cursus tempor ultrices. Donec volutpat metus sed risus venenatis, euismod viverra elit varius.</div>
+            <div class="listing-capacity">0 spots open</div>
+            <div class="listing-sub-description">Location or other meeting details depending on the category</div>
+            <div class="listing-buttons">
+                <button class="listing-button-detail">See details</button>
+                <button class="listing-button-join">Join</button>
+            </div>
+        </div>
+    </div>
+</div>
+</body>
+</html>

--- a/src/main/webapp/index.html
+++ b/src/main/webapp/index.html
@@ -10,6 +10,7 @@
     <div id="content">
       <h1>SPS Spring 2021 Team 52 Project</h1>
       <p>Project base.</p>
+      <p><a href="browse.html">Click here to go to the listing page prototype!</a></p>
     </div>
   </body>
 </html>


### PR DESCRIPTION
This pull request adds the first hardcoded prototype of the listings page including a first attempt at the site's layout and styling. At the moment it contains the barebones implementation and none of the links/buttons on the page have any effect. The main page now contains a link to the /browse.html page added here. The current layout for this pull request looks like the following:


![image](https://user-images.githubusercontent.com/48114346/112235551-23963c80-8bfc-11eb-94d7-d9780e0aafcd.png)
